### PR TITLE
Simple HTTP cache control middleware

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .gitignore
 node_modules
 test
+.travis.yml

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(express, opts) {
     types = new Typology(opts.typology || {});
 
   // Internal RAM cache
-  var ramCache = {};
+  var cache = {};
 
   // Building the router function
   function makeRouter(routes, o) {
@@ -48,8 +48,8 @@ module.exports = function(express, opts) {
         routeMiddlewares.push(middlewares.validate(types, route.validate));
 
       // RAM cache
-      if (route.ramCache)
-        routeMiddlewares.push(middlewares.ramCache(ramCache, route.ramCache));
+      if (route.cache)
+        routeMiddlewares.push(middlewares.cache(cache, route.cache));
 
       // HTTP cache
       if (route.httpCache)

--- a/index.js
+++ b/index.js
@@ -47,9 +47,13 @@ module.exports = function(express, opts) {
       if (route.validate)
         routeMiddlewares.push(middlewares.validate(types, route.validate));
 
-      // Cache
+      // RAM cache
       if (route.ramCache)
         routeMiddlewares.push(middlewares.ramCache(ramCache, route.ramCache));
+
+      // HTTP cache
+      if (route.httpCache)
+        routeMiddlewares.push(middlewares.httpCache(route.httpCache));
 
       // Applying after middlewares
       routeMiddlewares = routeMiddlewares.concat(after);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(express, opts) {
     types = new Typology(opts.typology || {});
 
   // Internal RAM cache
-  var cache = {};
+  var ramCache = {};
 
   // Building the router function
   function makeRouter(routes, o) {
@@ -48,8 +48,8 @@ module.exports = function(express, opts) {
         routeMiddlewares.push(middlewares.validate(types, route.validate));
 
       // Cache
-      if (route.cache)
-        routeMiddlewares.push(middlewares.cache(cache, route.cache));
+      if (route.ramCache)
+        routeMiddlewares.push(middlewares.ramCache(ramCache, route.ramCache));
 
       // Applying after middlewares
       routeMiddlewares = routeMiddlewares.concat(after);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/yomguithereal/dolman#readme",
   "dependencies": {
-    "typology": "1.0.0"
+    "typology": "1.1.0"
   },
   "devDependencies": {
     "async": "^1.5.0",

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -67,8 +67,11 @@ function httpCache(params) {
       });
     }
 
-    if (header)
+    if (header) {
       res.set('Cache-Control', header);
+    } else {
+      return next(new Error('Wrong parameter given for HTTP cache control'));
+    }
 
     return next();
   };

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -8,7 +8,7 @@
 /**
  * Creating a RAM caching middleware.
  */
-function ramCache(store, params) {
+function cache(store, params) {
   if (typeof params === 'string')
     params = {key: params};
 
@@ -114,7 +114,7 @@ function validate(types, def) {
 };
 
 module.exports = {
-  ramCache: ramCache,
+  cache: cache,
   httpCache: httpCache,
   validate: validate
 };

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -45,34 +45,33 @@ function cache(store, params) {
  * Leveraging HTTP cache control.
  */
 function httpCache(params) {
+  var header = null;
+
+  if (typeof params === 'string') {
+    header = params;
+  } else
+
+  // If params is an object, use special properties
+  // defined by API to set `max-age`.
+  if (params !== null && typeof params === 'function' || typeof params === 'object') {
+    var durations = {
+      seconds: 1, minutes: 60, hours: 3600, days: 86400, weeks: 604800
+    };
+
+    Object.keys(durations).some(function(key) {
+      if (params.hasOwnProperty(key)) {
+        header = 'private, max-age=' + durations[key] * params[key];
+        return header;
+      }
+    });
+
+    if (!header) {
+      throw new Error('Wrong parameter given for HTTP cache control');
+    }
+  }
+
   return function(req, res, next) {
-    var header = null;
-
-    if (typeof params === 'string')
-      header = params;
-
-    // If params is an object, use special properties
-    // defined by API to set `max-age`.
-    if (params !== null && typeof params === 'function' || typeof params === 'object') {
-
-      var durations = {
-        seconds: 1, minutes: 60, hours: 3600, days: 86400, weeks: 604800
-      };
-
-      Object.keys(durations).some(function(key) {
-        if (params.hasOwnProperty(key)) {
-          header = 'private, max-age=' + durations[key] * params[key];
-          return header;
-        }
-      });
-    }
-
-    if (header) {
-      res.set('Cache-Control', header);
-    } else {
-      return next(new Error('Wrong parameter given for HTTP cache control'));
-    }
-
+    res.set('Cache-Control', header);
     return next();
   };
 }

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -70,7 +70,7 @@ function httpCache(params) {
 
       if (factor > 0) {
         var maxAge = params[keys[factor]] * factor;
-        header = 'public, max-age=' + maxAge;
+        header = 'private, max-age=' + maxAge;
       }
     }
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -53,25 +53,18 @@ function httpCache(params) {
 
     // If params is an object, use special properties
     // defined by API to set `max-age`.
-    if (params !== null &&
-       (typeof params === 'function') || typeof params === 'object') {
+    if (params !== null && typeof params === 'function' || typeof params === 'object') {
 
-      var factor = 0,
-          keys = {
-            '1': 'seconds', '60': 'minutes', '3600': 'hours',
-            '86400': 'days', '604800': 'weeks'
-          };
+      var durations = {
+        seconds: 1, minutes: 60, hours: 3600, days: 86400, weeks: 604800
+      };
 
-      params.hasOwnProperty('seconds') ? factor = 1 : factor;
-      params.hasOwnProperty('minutes') ? factor = 60 : factor;
-      params.hasOwnProperty('hours') ? factor = 3600 : factor;
-      params.hasOwnProperty('days') ? factor = 86400 : factor;
-      params.hasOwnProperty('weeks') ? factor = 604800 : factor;
-
-      if (factor > 0) {
-        var maxAge = params[keys[factor]] * factor;
-        header = 'private, max-age=' + maxAge;
-      }
+      Object.keys(durations).some(function(key) {
+        if (params.hasOwnProperty(key)) {
+          header = 'private, max-age=' + durations[key] * params[key];
+          return header;
+        }
+      });
     }
 
     if (header)

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -6,9 +6,9 @@
  */
 
 /**
- * Creating a caching middleware.
+ * Creating a RAM caching middleware.
  */
-function cache(store, params) {
+function ramCache(store, params) {
   if (typeof params === 'string')
     params = {key: params};
 
@@ -74,6 +74,6 @@ function validate(types, def) {
 };
 
 module.exports = {
-  cache: cache,
+  ramCache: ramCache,
   validate: validate
 };

--- a/test/unit.js
+++ b/test/unit.js
@@ -457,24 +457,25 @@ describe('Router', function() {
     }, done);
   });
 
-  it('HTTP cache middle should throw an error on unexpected params', function(done) {
+  it('HTTP cache middle should throw an error on unexpected params.', function(done) {
     var app = express();
+    var router;
 
-    var router = dolman.router([
-      {
-        url: '/foo',
-        httpCache: {no: 'way'},
-        action: function(req, res) {
-          return res.ok();
+    function setup() {
+      router = dolman.router([
+        {
+          url: '/foo',
+          httpCache: {no: 'way'},
+          action: function(req, res) {
+            return res.ok();
+          }
         }
-      }
-    ]);
+      ]);
+      app.use(router);
+    }
 
-    app.use(router);
-
-    request(app)
-      .get('/foo')
-      .end(done);
+    assert.throws(setup, Error);
+    request(app).get('/foo').end(done);
   });
 
   // it('before middleware should work.', function() {

--- a/test/unit.js
+++ b/test/unit.js
@@ -374,6 +374,115 @@ describe('Router', function() {
     }, done);
   });
 
+  it('HTTP cache middleware should work.', function() {
+    var app = express();
+
+    var val1 = 'private, max-age=3600',
+        val2 = 'public, max-age=59', // 59 seconds
+        val3 = 'public, max-age=60', // 1 minute
+        val4 = 'public, max-age=7200', // 2 hours
+        val5 = 'public, max-age=259200', // 3 days
+        val6 = 'public, max-age=2419200'; // 4 weeks
+
+    var router = dolman.router([
+      {
+        url: '/string',
+        httpCache: val1,
+        action: function(req, res) {
+          return res.ok();
+        }
+      },
+      {
+        url: '/seconds',
+        httpCache: {seconds: 59},
+        action: function(req, res) {
+          return res.ok();
+        }
+      },
+      {
+        url: '/minutes',
+        httpCache: {minutes: 1},
+        action: function(req, res) {
+          return res.ok();
+        }
+      },
+      {
+        url: '/hours',
+        httpCache: {hours: 2},
+        action: function(req, res) {
+          return res.ok();
+        }
+      },
+      {
+        url: '/days',
+        httpCache: {days: 3},
+        action: function(req, res) {
+          return res.ok();
+        }
+      },
+      {
+        url: '/weeks',
+        httpCache: {weeks: 4},
+        action: function(req, res) {
+          return res.ok();
+        }
+      }
+    ]);
+
+    app.use(router);
+
+    async.series({
+      stringParam: function(next) {
+        request(app)
+          .get('/string')
+          .expect(function(res) {
+            assert(res.get('Cache-Control'), val1);
+            next();
+          });
+      },
+      seconds: function(next) {
+        request(app)
+          .get('seconds')
+          .expect(function(res) {
+            assert(res.get('Cache-Control'), val2);
+            next();
+          });
+      },
+      minutes: function(next) {
+        request(app)
+          .get('minutes')
+          .expect(function(res) {
+            assert(res.get('Cache-Control'), val3);
+            next();
+          });
+      },
+      hours: function(next) {
+        request(app)
+          .get('hours')
+          .expect(function(res) {
+            assert(res.get('Cache-Control'), val4);
+            next();
+          });
+      },
+      days: function(next) {
+        request(app)
+          .get('days')
+          .expect(function(res) {
+            assert(res.get('Cache-Control'), val5);
+            next();
+          });
+      },
+      weeks: function(next) {
+        request(app)
+          .get('weeks')
+          .expect(function(res) {
+            assert(res.get('Cache-Control'), val6);
+            next();
+          });
+      }
+    });
+  });
+
   // it('before middleware should work.', function() {
 
   // });

--- a/test/unit.js
+++ b/test/unit.js
@@ -290,7 +290,7 @@ describe('Router', function() {
     }, done);
   });
 
-  it('cache middleware should work.', function(done) {
+  it('RAM cache middleware should work.', function(done) {
     var app = express(),
         one = 0,
         two = 0;
@@ -298,7 +298,7 @@ describe('Router', function() {
     var router = dolman.router([
       {
         url: '/one',
-        cache: 'one',
+        ramCache: 'one',
         action: function(req, res) {
           one++;
           return res.ok({hello: 'world'});
@@ -306,7 +306,7 @@ describe('Router', function() {
       },
       {
         url: '/two',
-        cache: {
+        ramCache: {
           key: 'two',
           hasher: function(req) {
             return req.query.title;

--- a/test/unit.js
+++ b/test/unit.js
@@ -298,7 +298,7 @@ describe('Router', function() {
     var router = dolman.router([
       {
         url: '/one',
-        ramCache: 'one',
+        cache: 'one',
         action: function(req, res) {
           one++;
           return res.ok({hello: 'world'});
@@ -306,7 +306,7 @@ describe('Router', function() {
       },
       {
         url: '/two',
-        ramCache: {
+        cache: {
           key: 'two',
           hasher: function(req) {
             return req.query.title;

--- a/test/unit.js
+++ b/test/unit.js
@@ -377,12 +377,12 @@ describe('Router', function() {
   it('HTTP cache middleware should work.', function(done) {
     var app = express();
 
-    var val1 = 'private, max-age=3600',
-        val2 = 'public, max-age=59', // 59 seconds
-        val3 = 'public, max-age=60', // 1 minute
-        val4 = 'public, max-age=7200', // 2 hours
-        val5 = 'public, max-age=259200', // 3 days
-        val6 = 'public, max-age=2419200'; // 4 weeks
+    var val1 = 'public, max-age=3600',
+        val2 = 'private, max-age=59', // 59 seconds
+        val3 = 'private, max-age=60', // 1 minute
+        val4 = 'private, max-age=7200', // 2 hours
+        val5 = 'private, max-age=259200', // 3 days
+        val6 = 'private, max-age=2419200'; // 4 weeks
 
     var action = function(req, res) {
       return res.ok();

--- a/test/unit.js
+++ b/test/unit.js
@@ -374,7 +374,7 @@ describe('Router', function() {
     }, done);
   });
 
-  it('HTTP cache middleware should work.', function() {
+  it('HTTP cache middleware should work.', function(done) {
     var app = express();
 
     var val1 = 'private, max-age=3600',
@@ -384,48 +384,40 @@ describe('Router', function() {
         val5 = 'public, max-age=259200', // 3 days
         val6 = 'public, max-age=2419200'; // 4 weeks
 
+    var action = function(req, res) {
+      return res.ok();
+    };
+
     var router = dolman.router([
       {
         url: '/string',
         httpCache: val1,
-        action: function(req, res) {
-          return res.ok();
-        }
+        action: action
       },
       {
         url: '/seconds',
         httpCache: {seconds: 59},
-        action: function(req, res) {
-          return res.ok();
-        }
+        action: action
       },
       {
         url: '/minutes',
         httpCache: {minutes: 1},
-        action: function(req, res) {
-          return res.ok();
-        }
+        action: action
       },
       {
         url: '/hours',
         httpCache: {hours: 2},
-        action: function(req, res) {
-          return res.ok();
-        }
+        action: action
       },
       {
         url: '/days',
         httpCache: {days: 3},
-        action: function(req, res) {
-          return res.ok();
-        }
+        action: action
       },
       {
         url: '/weeks',
         httpCache: {weeks: 4},
-        action: function(req, res) {
-          return res.ok();
-        }
+        action: action
       }
     ]);
 
@@ -435,52 +427,34 @@ describe('Router', function() {
       stringParam: function(next) {
         request(app)
           .get('/string')
-          .expect(function(res) {
-            assert(res.get('Cache-Control'), val1);
-            next();
-          });
+          .expect('Cache-Control', val1, next);
       },
       seconds: function(next) {
         request(app)
-          .get('seconds')
-          .expect(function(res) {
-            assert(res.get('Cache-Control'), val2);
-            next();
-          });
+          .get('/seconds')
+          .expect('Cache-Control', val2, next);
       },
       minutes: function(next) {
         request(app)
-          .get('minutes')
-          .expect(function(res) {
-            assert(res.get('Cache-Control'), val3);
-            next();
-          });
+          .get('/minutes')
+          .expect('Cache-Control', val3, next);
       },
       hours: function(next) {
         request(app)
-          .get('hours')
-          .expect(function(res) {
-            assert(res.get('Cache-Control'), val4);
-            next();
-          });
+          .get('/hours')
+          .expect('Cache-Control', val4, next);
       },
       days: function(next) {
         request(app)
-          .get('days')
-          .expect(function(res) {
-            assert(res.get('Cache-Control'), val5);
-            next();
-          });
+          .get('/days')
+          .expect('Cache-Control', val5, next);
       },
       weeks: function(next) {
         request(app)
-          .get('weeks')
-          .expect(function(res) {
-            assert(res.get('Cache-Control'), val6);
-            next();
-          });
+          .get('/weeks')
+          .expect('Cache-Control', val6, next);
       }
-    });
+    }, done);
   });
 
   // it('before middleware should work.', function() {

--- a/test/unit.js
+++ b/test/unit.js
@@ -457,6 +457,26 @@ describe('Router', function() {
     }, done);
   });
 
+  it('HTTP cache middle should throw an error on unexpected params', function(done) {
+    var app = express();
+
+    var router = dolman.router([
+      {
+        url: '/foo',
+        httpCache: {no: 'way'},
+        action: function(req, res) {
+          return res.ok();
+        }
+      }
+    ]);
+
+    app.use(router);
+
+    request(app)
+      .get('/foo')
+      .end(done);
+  });
+
   // it('before middleware should work.', function() {
 
   // });


### PR DESCRIPTION
I'd be happy to discuss with you the relevance and implementation of this feature in this pull request.

This middleware provides a simple abstraction to set the [`max-age` value of the HTTP `Cache-Control`](https://en.wikipedia.org/wiki/Web_cache#Cache_control) header in a fluent way. One could rely on `express` usage of `Etag` mechanism by default and not even pay attention — that's fine. But in cases where a finer-grained, per-resource HTTP caching strategy is involved, it could come handy. 
### Changes

`cache` is now labelled `ramCache` and API changes accordingly.
### API

``` javascript
var router = dolman.router([
  // Use `httpCache`. Setting a string value equals setting `Cache-Control` header manually.
  {
    url: '/foo',
    httpCache: 'public, max-age=3600, s-maxage=3600' 
  }

  // Setting using an object, where key is the time unit and value is the corresponding value.
  // Accept `seconds` up to `weeks`. Doesn't combine values. If several values are given,
  // only the last one is taken into account.
  {
    url: '/bar',
    httpCache: {minutes: 30}
  },
  {
    url: '/baz',
    ramCache: 'foobarbaz', // still works, mind the name change!
    httpCache: {
      hours: 1,
      minutes: 30,
      seconds: 25
    } // => useless - ultimately set to 25 seconds
  }
]);
```
